### PR TITLE
Simplify kepler image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,13 @@ FROM debian:bookworm
 
 RUN apt-get update && apt-get install -y libpq5 ca-certificates openssl
 
-COPY --from=builder \
-	/target/release/kepler \
-	/usr/local/bin/
+# Create app directory
+WORKDIR /app
 
-WORKDIR /root
+# Copy binary to PATH
+COPY --from=builder /target/release/kepler /usr/local/bin/
 
+# Copy migrations to the app directory
 ADD ./migrations ./migrations
 
-ENTRYPOINT ["/usr/local/bin/kepler", "--migrate"]
+ENTRYPOINT ["kepler", "--migrate"]

--- a/README.md
+++ b/README.md
@@ -90,16 +90,8 @@ Kepler currently supports two data sources, [National Vulnerability Database](ht
 To import NIST records from all available years (2002 to 2025):
 
 ```bash
-for year in $(seq 2002 2025); do 
-    docker run --rm \
-        -v $(pwd)/data:/data:Z \
-        -e DB_HOST=db \
-        -e DB_PORT=5432 \
-        -e DB_USER=kepler \
-        -e DB_PASSWORD=kepler \
-        -e DB_DATABASE=kepler \
-        --network=kepler_default \
-        kepler:dev import_nist $year -d /data
+for year in $(seq 2002 2025); do
+  docker exec -it kepler kepler import_nist $year -d /data
 done
 ```
 
@@ -110,19 +102,16 @@ done
 Example - Refresh data for 2025
 
 ```bash
-for year in $(seq 2025 2025); do 
-    docker run --rm \
-        -v $(pwd)/data:/data:Z \
-        -e DB_HOST=db \
-        -e DB_PORT=5432 \
-        -e DB_USER=kepler \
-        -e DB_PASSWORD=kepler \
-        -e DB_DATABASE=kepler \
-        -e KEPLER_BATCH_SIZE=5000 \
-        --network=kepler_default \
-        kepler:dev import_nist $year -d /data --refresh
-done
+docker  exec -it kepler kepler import_nist 2025 -d /data --refresh
 ```
+
+Example - Custom batch size `-e KEPLER_BATCH_SIZE`
+
+```bash
+docker  exec -it -e KEPLER_BATCH_SIZE=4500 kepler kepler import_nist 2025 -d /data --refresh
+```
+
+> NOTE: Postgres supports 65535 params total so be aware when changing the default `KEPLER_BATCH_SIZE=5000` - [Postgres limits](https://www.postgresql.org/docs/current/limits.html)
 
 ### Database tear down
 

--- a/README.md
+++ b/README.md
@@ -102,16 +102,16 @@ done
 Example - Refresh data for 2025
 
 ```bash
-docker  exec -it kepler kepler import_nist 2025 -d /data --refresh
+docker exec -it kepler kepler import_nist 2025 -d /data --refresh
 ```
 
-Example - Custom batch size `-e KEPLER_BATCH_SIZE`
+Example - Custom batch size `-e KEPLER__BATCH_SIZE`
 
 ```bash
-docker  exec -it -e KEPLER_BATCH_SIZE=4500 kepler kepler import_nist 2025 -d /data --refresh
+docker exec -it -e KEPLER__BATCH_SIZE=4500 kepler kepler import_nist 2025 -d /data --refresh
 ```
 
-> NOTE: Postgres supports 65535 params total so be aware when changing the default `KEPLER_BATCH_SIZE=5000` - [Postgres limits](https://www.postgresql.org/docs/current/limits.html)
+> NOTE: Postgres supports 65535 params total so be aware when changing the default `KEPLER__BATCH_SIZE=5000` - [Postgres limits](https://www.postgresql.org/docs/current/limits.html)
 
 ### Database tear down
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - DB_USER=kepler
       - DB_PASSWORD=kepler
       - DB_DATABASE=kepler
-      - KEPLER_BATCH_SIZE=5000 
+      - KEPLER__BATCH_SIZE=5000 
     ports:
       - "8000:8000"
 

--- a/domain-db/src/db/mod.rs
+++ b/domain-db/src/db/mod.rs
@@ -25,7 +25,7 @@ pub mod schema;
 ///
 /// DOCS: https://www.postgresql.org/docs/current/limits.html
 pub static KEPLER_BATCH_SIZE: LazyLock<usize> = LazyLock::new(|| {
-    env::var("KEPLER_BATCH_SIZE")
+    env::var("KEPLER__BATCH_SIZE")
         .ok()
         .and_then(|val| val.parse::<usize>().ok())
         .unwrap_or(5000)
@@ -80,7 +80,7 @@ impl PostgresRepository {
 
     /// Insert a list of objects into the database if they don't already exist.
     ///
-    /// Insertion is done in batches of size `KEPLER_BATCH_SIZE` to avoid exceeding the maximum number of parameters = *(65535)* for PostgreSQL  
+    /// Insertion is done in batches of size `KEPLER__BATCH_SIZE` to avoid exceeding the maximum number of parameters = *(65535)* for PostgreSQL  
     ///
     /// Returns a [`HashMap<String, i32>`] of CVE IDs to their assigned object IDs.
     pub fn insert_objects(
@@ -102,7 +102,7 @@ impl PostgresRepository {
         Ok(inserted_object_ids)
     }
 
-    /// Inserts [`schema::objects`] into database in batches of size `KEPLER_BATCH_SIZE`
+    /// Inserts [`schema::objects`] into database in batches of size `KEPLER__BATCH_SIZE`
     pub fn batch_insert_objects(
         &self,
         values_list: &[models::NewObject],

--- a/kepler/src/main.rs
+++ b/kepler/src/main.rs
@@ -138,7 +138,7 @@ pub fn import_nist(
     cve_list: Vec<nist::cve::CVE>,
 ) -> Result<usize> {
     log::info!("connected to database, importing records ...");
-    log::info!("configured 'KEPLER_BATCH_SIZE' {}", &*KEPLER_BATCH_SIZE);
+    log::info!("configured 'KEPLER__BATCH_SIZE' {}", &*KEPLER_BATCH_SIZE);
     log::info!("{} CVEs pending import", cve_list.len());
 
     let mut num_imported = 0;


### PR DESCRIPTION
# Simplify kepler image

Simplified `kepler` dockerfile and updated DOCS to use `docker exec` instead of creating new container and than running commands in it with `docker run`. 

I ran some tests using these `podman` commands to make sure importing was still working the same way as before.

```bash
podman exec -it kepler kepler import_nist 2025 -d /data
```

```bash
for year in $(seq 2002 2025); do
  podman exec -it  kepler kepler import_nist $year -d /data
done
```


REFS
- https://docs.docker.com/reference/cli/docker/container/run/
- https://docs.docker.com/reference/cli/docker/container/exec/  


## I have 

- [x] run `cargo fmt`;
- [x] run `cargo clippy`;
- [x] run `cargo test`and all tests pass;
- [ ] linked to the originating issue (if applicable).
